### PR TITLE
Fix IME input handling (e.g., Korean, Japanese, Chinese)

### DIFF
--- a/streamlit_chat_prompt/frontend/src/components/ChatInput.tsx
+++ b/streamlit_chat_prompt/frontend/src/components/ChatInput.tsx
@@ -33,6 +33,7 @@ export class ChatInput extends StreamlitComponentBase<State, Props> {
   private maxImageFileCount: number = 20;
   private maxDocumentFileSizeInBytes: number = 4.5 * 1024 * 1024; // Default 4.5MB
   private maxDocumentFileCount: number = 5;
+  private isComposing = false;
 
   constructor(props: Props) {
     super(props as any);
@@ -683,11 +684,22 @@ export class ChatInput extends StreamlitComponentBase<State, Props> {
     this.focusTextField();
   }
 
+  handleCompositionStart = () => {
+    this.isComposing = true;
+  };
+
+  handleCompositionEnd = () => {
+    this.isComposing = false;
+  };
+
   async handleKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
     if (this.state.disabled || this.state.clipboardInspector.open) return;
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
-      await this.handleSubmit();
+
+      if (!this.isComposing) {
+          await this.handleSubmit();
+      }
     }
   }
 
@@ -872,6 +884,8 @@ export class ChatInput extends StreamlitComponentBase<State, Props> {
                 value={this.state.text}
                 onChange={this.handleTextChange}
                 onKeyDown={this.handleKeyDown}
+                onCompositionStart={this.handleCompositionStart}
+                onCompositionEnd={this.handleCompositionEnd}
                 disabled={this.state.disabled}
                 placeholder={this.props.args?.placeholder ?? ''}
                 inputRef={this.textFieldRef}

--- a/streamlit_chat_prompt/frontend/src/components/TextField.tsx
+++ b/streamlit_chat_prompt/frontend/src/components/TextField.tsx
@@ -5,6 +5,8 @@ interface ChatTextFieldProps {
     value: string;
     onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
     onKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => void;
+    onCompositionStart: (e: React.CompositionEvent<HTMLInputElement>) => void;
+    onCompositionEnd: (e: React.CompositionEvent<HTMLInputElement>) => void;
     disabled: boolean;
     placeholder: string;
     inputRef: React.RefObject<HTMLInputElement>;
@@ -17,6 +19,8 @@ export const ChatTextField: React.FC<ChatTextFieldProps> = ({
     value,
     onChange,
     onKeyDown,
+    onCompositionStart,
+    onCompositionEnd,
     disabled,
     placeholder,
     inputRef,
@@ -31,6 +35,8 @@ export const ChatTextField: React.FC<ChatTextFieldProps> = ({
             value={value}
             onChange={onChange}
             onKeyDown={onKeyDown}
+            onCompositionStart={onCompositionStart}
+            onCompositionEnd={onCompositionEnd}
             placeholder={placeholder}
             variant="standard"
             inputRef={inputRef}


### PR DESCRIPTION
## Summary

This pull request fixes an input handling issue related to IME (Input Method Editor) composition events.

Previously, when users typed text using an IME (e.g. Korean, Japanese, or Chinese) only the last composed character was transmitted unless the user manually moved the cursor (e.g., by using arrow keys or clicking elsewhere). 

This occurred because the input value was being submitted during an ongoing composition, rather than after the composition was finalized.

## Changes

- Added `compositionstart` and `compositionend` event handlers.
- Introduced an `isComposing` flag to detect ongoing composition.
- Modified submit logic to only trigger after composition is complete.
- Ensured that IME-based input flows smoothly without requiring cursor movement.

## Impact

- Correctly handles text input with IME for Korean, Japanese, and Chinese that use character composition.
- Regular (non-IME) typing behavior remains unaffected.
- Tested on Chrome and Safari with Korean input.