### PR TITLE
add support for 'document' file attachments

### DIFF
--- a/examples/example.py
+++ b/examples/example.py
@@ -1,6 +1,5 @@
 import base64
 import uuid
-import json
 from dataclasses import dataclass
 from io import BytesIO
 from typing import List

--- a/examples/example.py
+++ b/examples/example.py
@@ -1,5 +1,6 @@
 import base64
 import uuid
+import json
 from dataclasses import dataclass
 from io import BytesIO
 from typing import List
@@ -129,8 +130,9 @@ for chat_message in st.session_state.messages:
             if chat_message.content.files:  # Change from images to files
                 for file_data in chat_message.content.files:
                     st.divider()
-                    if file_data.type.startswith("image/"):
-                        # Handle images as before
+
+                    if file_data.is_image:
+                        # Handle images
                         st.markdown("Using `st.markdown`")
                         st.markdown(
                             f"![Image example](data:{file_data.type};{file_data.format},{file_data.data})"
@@ -140,34 +142,28 @@ for chat_message in st.session_state.messages:
                         st.markdown("Using `st.image`")
                         image = Image.open(BytesIO(base64.b64decode(file_data.data)))
                         st.image(image)
-                    elif file_data.type == "application/pdf":
-                        st.markdown("PDF File:")
+
+                    else:
+                        # Handle documents
                         st.markdown(f"Filename: {file_data.name}")
-                        pdf_bytes = BytesIO(base64.b64decode(file_data.data))
+                        file_bytes = BytesIO(base64.b64decode(file_data.data))
+
+                        # Only show preview for previewable documents
+                        if file_data.is_previewable:
+                            with st.expander("Preview"):
+                                text_content = file_bytes.getvalue().decode("utf-8")
+                                st.code(text_content)
+
+                            # Reset for download
+                            file_bytes.seek(0)
+
+                        # Download button for all document types
                         st.download_button(
                             label=f"Download {file_data.name}",
-                            data=pdf_bytes,
+                            data=file_bytes,
                             file_name=file_data.name,
                             mime=file_data.type,
-                            key=f"download_{file_data.type}_{uuid.uuid4()}",
-                        )
-                    elif file_data.type == "text/markdown":
-                        st.markdown("Markdown File:")
-                        st.markdown(f"Filename: {file_data.name}")
-                        md_bytes = BytesIO(base64.b64decode(file_data.data))
-
-                        # preview markdown content
-                        with st.expander("Preview"):
-                            md_content = md_bytes.getvalue().decode("utf-8")
-                            st.markdown(md_content)
-
-                        md_bytes.seek(0)  # Reset buffer position for download
-                        st.download_button(
-                            label=f"Download {file_data.name}",
-                            data=md_bytes,
-                            file_name=file_data.name,
-                            mime=file_data.type,
-                            key=f"download_{file_data.type}_{uuid.uuid4()}",
+                            key=f"download_{file_data.file_type}_{uuid.uuid4()}",
                         )
         else:
             st.markdown(chat_message.content)

--- a/streamlit_chat_prompt/__init__.py
+++ b/streamlit_chat_prompt/__init__.py
@@ -66,7 +66,7 @@ class FileData(BaseModel):
     data: str
     name: Optional[str] = None
     size: Optional[int] = None
-    file_type: Literal['image', 'pdf', 'markdown', 'audio'] = None  # For internal type tracking
+    file_type: Literal['image', 'document'] = None  # todo: add 'media' type for audio/video
 
     @property
     def is_image(self) -> bool:
@@ -75,6 +75,24 @@ class FileData(BaseModel):
     @property
     def is_document(self) -> bool:
         return not self.is_image
+
+    @property
+    def is_previewable(self) -> bool:
+        """Returns whether the document can be previewed in the browser"""
+        if self.is_image:
+            return True
+
+        previewable_mime_types = [
+            'text/markdown',
+            'text/plain',
+            'text/html',
+            'text/csv',
+            'application/json'
+        ]
+
+        return self.type in previewable_mime_types or (
+            self.name and any(self.name.lower().endswith(ext) for ext in ['.md', '.txt', '.html', '.htm', '.csv', '.json'])
+        )
 
 
 class PromptReturn(BaseModel):
@@ -295,11 +313,15 @@ def prompt(
                     file_format = parts[1].split(",")[0]
                     file_data_content = parts[1].split(",")[1]
 
+                    # Determine file_type value - either 'image' or 'document'
+                    file_type_value = 'image' if file_type.startswith('image/') else 'document'
+
                     file = FileData(
                         type=file_type,
                         format=file_format,
                         data=file_data_content,
-                        name=None
+                        name=None,
+                        file_type=file_type_value
                     )
 
                     processed_files.append(file)
@@ -310,10 +332,22 @@ def prompt(
                             type=file_type,
                             format=file_format,
                             data=file_data_content,
-                            name=None
+                            name=None,
+                            file_type='image'
                         ))
 
                 else:  # If it's already a dictionary
+                    # Convert file_type to our simplified system if needed
+                    if 'file_type' in file_data:
+                        # Map any incoming file_type to either 'image' or 'document'
+                        if file_data['type'].startswith('image/') or file_data['file_type'] == 'image':
+                            file_data['file_type'] = 'image'
+                        else:
+                            file_data['file_type'] = 'document'
+                    else:
+                        # If no file_type is provided, determine it from the MIME type
+                        file_data['file_type'] = 'image' if file_data['type'].startswith('image/') else 'document'
+
                     file = FileData(**file_data)
                     processed_files.append(file)
 
@@ -323,7 +357,8 @@ def prompt(
                             type=file.type,
                             format=file.format,
                             data=file.data,
-                            name=getattr(file, 'name', None)
+                            name=getattr(file, 'name', None),
+                            file_type='image'
                         ))
 
         if not processed_files and not component_value.get("text"):

--- a/streamlit_chat_prompt/__init__.py
+++ b/streamlit_chat_prompt/__init__.py
@@ -27,6 +27,23 @@ DEFAULT_IMAGE_COUNT = 20
 DEFAULT_DOCUMENT_FILE_SIZE = 4.5 * 1024 * 1024  # 4.5MB
 DEFAULT_DOCUMENT_COUNT = 5
 
+PREVIEWABLE_MIME_TYPES = [
+    'text/markdown',
+    'text/plain',
+    'text/html',
+    'text/csv',
+    'application/json'
+]
+
+PREVIEWABLE_EXTENSIONS = [
+    '.md',
+    '.txt',
+    '.html',
+    '.htm',
+    '.csv',
+    '.json'
+]
+
 # Declare a Streamlit component. `declare_component` returns a function
 # that is used to create instances of the component. We're naming this
 # function "_component_func", with an underscore prefix, because we don't want
@@ -79,19 +96,18 @@ class FileData(BaseModel):
     @property
     def is_previewable(self) -> bool:
         """Returns whether the document can be previewed in the browser"""
+        # Images are always previewable
         if self.is_image:
             return True
 
-        previewable_mime_types = [
-            'text/markdown',
-            'text/plain',
-            'text/html',
-            'text/csv',
-            'application/json'
-        ]
+        # Check MIME type first
+        if self.type in PREVIEWABLE_MIME_TYPES:
+            return True
 
-        return self.type in previewable_mime_types or (
-            self.name and any(self.name.lower().endswith(ext) for ext in ['.md', '.txt', '.html', '.htm', '.csv', '.json'])
+        # Fallback to extension check
+        return bool(
+            self.name and
+            any(self.name.lower().endswith(ext) for ext in PREVIEWABLE_EXTENSIONS)
         )
 
 

--- a/streamlit_chat_prompt/frontend/src/components/ChatInput.tsx
+++ b/streamlit_chat_prompt/frontend/src/components/ChatInput.tsx
@@ -22,7 +22,7 @@ import { PromptData } from "./PromptData";
 import { Props } from "./Props";
 import { State } from "./State";
 import { ChatTextField } from "./TextField";
-import { SUPPORTED_FILE_TYPES, SupportedFile, getAcceptedFileString, isValidFileType, getFileType } from './Types';
+import { SupportedFile, getAcceptedFileString, isValidFileType, isPreviewableDocument, getFileType } from './Types';
 
 export class ChatInput extends StreamlitComponentBase<State, Props> {
   private fileInputRef: React.RefObject<HTMLInputElement>;
@@ -204,73 +204,49 @@ export class ChatInput extends StreamlitComponentBase<State, Props> {
       }
       const isImage = fileType === 'image';
       const currentImageCount = this.state.files.filter(f => f.type === 'image').length;
-      const currentDocumentCount = this.state.files.filter(f => f.type !== 'image').length;
+      const currentDocumentCount = this.state.files.filter(f => f.type === 'document').length;
 
       if (isImage && currentImageCount >= this.maxImageFileCount) {
         this.showNotification(
-          `Maximum of ${this.maxImageFileCount} images allowed`,
-          "error"
-        );
-        return null;
-      } else if (!isImage && currentDocumentCount >= this.maxDocumentFileCount) {
-        this.showNotification(
-          `Maximum of ${this.maxDocumentFileCount} documents allowed`,
+          `Maximum of ${this.maxImageFileCount} images reached`,
           "error"
         );
         return null;
       }
-
-      // Check file size for documents
-      if (!isImage && file.size > this.maxDocumentFileSizeInBytes) {
-        const sizeInMb = (this.maxDocumentFileSizeInBytes / (1024 * 1024)).toFixed(1);
+      if (!isImage && currentDocumentCount >= this.maxDocumentFileCount) {
         this.showNotification(
-          `File "${file.name}" exceeds document size limit of ${sizeInMb}MB`,
+          `Maximum of ${this.maxDocumentFileCount} documents reached`,
           "error"
         );
         return null;
       }
       // Process based on file type
-      switch(fileType) {
-        case 'image':
-          const processedImage = await processImage(file, this.maxImageFileSizeInBytes, this.maxImageFileDimensionInPixels);
-          if (processedImage) {
-            return {
-              file: processedImage,
-              type: 'image',
-              preview: URL.createObjectURL(processedImage),
-              size: processedImage.size
-            };
-          }
-          break;
-          
-        case 'pdf':
+      if (isImage) {
+        const processedImage = await processImage(
+          file, 
+          this.maxImageFileSizeInBytes, 
+          this.maxImageFileDimensionInPixels
+        );
+        if (processedImage) {
           return {
-            file,
-            type: 'pdf',
-            preview: undefined,
-            size: file.size
+            file: processedImage,
+            type: 'image',
+            preview: URL.createObjectURL(processedImage),
+            size: processedImage.size
           };
-          
-        case 'markdown':
-          const markdownFile = file.type.includes('markdown') ? file :
-            new File([file], file.name, { type: 'text/markdown' });
-
-          const preview = await this.generateMarkdownPreview(file);
-
-          return {
-            file: markdownFile,
-            type: 'markdown',
-            preview,
-            size: file.size
-          };
-          
-        case 'document':
-          return {
-            file,
-            type: 'document',
-            preview: undefined,
-            size: file.size
-          };
+        }
+      } else {
+        // All non-image files are treated as documents
+        let preview: string | undefined;
+        if (isPreviewableDocument(file)) {
+          preview = await this.generateMarkdownPreview(file);
+        }
+        return {
+          file,
+          type: 'document',
+          preview: preview,
+          size: file.size
+        };
       }
 
       this.showNotification(`Unsupported file type: ${file.type}`, "error");
@@ -306,7 +282,10 @@ export class ChatInput extends StreamlitComponentBase<State, Props> {
           const fileName = fileData.name || `default-file-${Math.random().toString(36).slice(2)}`;
           const file = new File([blob], fileName, { type: fileData.type });
 
-          if (fileData.type.startsWith('image/')) {
+          // Use our consolidated type system
+          const fileType = getFileType(file);
+          
+          if (fileType === 'image') {
             const processedImage = await processImage(file, this.maxImageFileSizeInBytes);
             if (processedImage) {
               processedFiles.push({
@@ -316,17 +295,18 @@ export class ChatInput extends StreamlitComponentBase<State, Props> {
                 size: processedImage.size
               });
             }
-          } else if (SUPPORTED_FILE_TYPES.PDF.includes(fileData.type)) {
+          } else if (fileType === 'document') {
+            // For previewable documents, generate preview
+            let preview: string | undefined;
+            if (isPreviewableDocument(file)) {
+              preview = await this.generateMarkdownPreview(file);
+            }
+
             processedFiles.push({
               file,
-              type: 'pdf',
-              size: file.size,
-            });
-          } else if (SUPPORTED_FILE_TYPES.MARKDOWN.includes(fileData.type)) {
-            processedFiles.push({
-              file,
-              type: 'markdown',
-              size: file.size,
+              type: 'document',
+              preview,
+              size: file.size
             });
           }
         } catch (error) {
@@ -713,79 +693,45 @@ export class ChatInput extends StreamlitComponentBase<State, Props> {
   }
 
   private renderFilePreview(file: SupportedFile, index: number) {
-    const { theme } = this.props;
+    if (file.type === 'image') {
+      return (
+        <img
+          src={file.preview}
+          alt={`Upload ${index}`}
+          style={{ maxWidth: '100px', maxHeight: '100px', objectFit: 'contain' }}
+        />
+      );
+    } 
 
-    switch (file.type) {
-      case 'image':
-        return file.preview && (
-          <img
-            src={file.preview}
-            alt={`Upload ${index}`}
-            style={{ height: '80px', width: 'auto', objectFit: 'cover' }}
-          />
-        );
-
-      case 'pdf':
-        return (
-          <Box sx={{ p: 1, display: 'flex', alignItems: 'center' }}>
-            <PictureAsPdf sx={{ color: theme?.textColor }} />
-            <Typography sx={{ ml: 1, color: theme?.textColor }}>
-              {file.file.name}
-            </Typography>
-          </Box>
-        );
-
-      case 'markdown':
-        return (
-          <Box
-            sx={{
-              p: 1,
-              display: 'flex',
-              flexDirection: 'column',
-              minWidth: '200px',
-              maxWidth: '300px'
-            }}
-          >
-            <Box sx={{ display: 'flex', alignItems: 'center', mb: 0.5 }}>
-              <Description sx={{ color: theme?.textColor }} />
-              <Typography
-                sx={{
-                  ml: 1,
-                  color: theme?.textColor,
-                  fontWeight: 'medium'
-                }}
-              >
-                {file.file.name}
-              </Typography>
-            </Box>
-            {file.preview && (
-              <Typography
-                sx={{
-                  color: theme?.textColor,
-                  fontSize: '0.75rem',
-                  opacity: 0.8,
-                  fontFamily: 'monospace',
-                  whiteSpace: 'pre-wrap',
-                  overflow: 'hidden',
-                  maxHeight: '60px',
-                  backgroundColor: `${theme?.secondaryBackgroundColor}66`,
-                  p: 0.5,
-                  borderRadius: 1,
-                }}
-              >
-                {file.preview}
-              </Typography>
-            )}
-          </Box>
-        );
-
-      default:
-        return (
-          <Typography sx={{ p: 1, color: theme?.textColor }}>
-            {file.file.name}
-          </Typography>
-        );
+    // Handle document previews
+    if (isPreviewableDocument(file.file)) {
+      return (
+        <div style={{ padding: '8px', border: '1px solid #e0e0e0', borderRadius: '4px', margin: '4px 0' }}>
+          <div>{file.file.name}</div>
+          {file.preview && (
+            <pre style={{ 
+              margin: '8px 0 0 0',
+              padding: '8px',
+              background: '#f5f5f5',
+              borderRadius: '4px',
+              maxHeight: '200px',
+              overflow: 'auto',
+              whiteSpace: 'pre-wrap',
+              wordWrap: 'break-word'
+            }}>
+              {file.preview}
+            </pre>
+          )}
+        </div>
+      );
     }
+
+    // Default document display without preview
+    return (
+      <div style={{ padding: '8px', border: '1px solid #e0e0e0', borderRadius: '4px', margin: '4px 0' }}>
+        <div>{file.file.name}</div>
+      </div>
+    );
   }
 
   render() {

--- a/streamlit_chat_prompt/frontend/src/components/ChatInput.tsx
+++ b/streamlit_chat_prompt/frontend/src/components/ChatInput.tsx
@@ -22,7 +22,7 @@ import { PromptData } from "./PromptData";
 import { Props } from "./Props";
 import { State } from "./State";
 import { ChatTextField } from "./TextField";
-import { SUPPORTED_FILE_TYPES, SupportedFile, getAcceptedFileString } from './Types';
+import { SUPPORTED_FILE_TYPES, SupportedFile, getAcceptedFileString, isValidFileType, getFileType } from './Types';
 
 export class ChatInput extends StreamlitComponentBase<State, Props> {
   private fileInputRef: React.RefObject<HTMLInputElement>;
@@ -191,23 +191,20 @@ export class ChatInput extends StreamlitComponentBase<State, Props> {
     return existingFiles.some(existing =>
       existing.file.name === newFile.name &&
       existing.file.size === newFile.size &&
-      existing.type === (newFile.type.startsWith('image/') ? 'image' :
-        newFile.type === 'application/pdf' ? 'pdf' :
-          'markdown')
+      existing.type === getFileType(newFile)
     );
   }
 
   private async processFile(file: File): Promise<SupportedFile | null> {
     try {
-      const isImage = file.type.startsWith('image/');
-      const isPDF = SUPPORTED_FILE_TYPES.PDF.includes(file.type) ||
-        file.name.toLowerCase().endsWith('.pdf');
-      const isMarkdown = SUPPORTED_FILE_TYPES.MARKDOWN.includes(file.type) ||
-        file.name.toLowerCase().endsWith('.md');
-
-      // Check file counts
+      const fileType = getFileType(file);
+      if (!isValidFileType(file)) {
+        this.showNotification(`Unsupported file type: ${file.type}`, "error");
+        return null;
+      }
+      const isImage = fileType === 'image';
       const currentImageCount = this.state.files.filter(f => f.type === 'image').length;
-      const currentDocumentCount = this.state.files.filter(f => f.type === 'pdf' || f.type === 'markdown').length;
+      const currentDocumentCount = this.state.files.filter(f => f.type !== 'image').length;
 
       if (isImage && currentImageCount >= this.maxImageFileCount) {
         this.showNotification(
@@ -233,35 +230,47 @@ export class ChatInput extends StreamlitComponentBase<State, Props> {
         return null;
       }
       // Process based on file type
-      if (isImage) {
-        const processedImage = await processImage(file, this.maxImageFileSizeInBytes, this.maxImageFileDimensionInPixels);
-        if (processedImage) {
+      switch(fileType) {
+        case 'image':
+          const processedImage = await processImage(file, this.maxImageFileSizeInBytes, this.maxImageFileDimensionInPixels);
+          if (processedImage) {
+            return {
+              file: processedImage,
+              type: 'image',
+              preview: URL.createObjectURL(processedImage),
+              size: processedImage.size
+            };
+          }
+          break;
+          
+        case 'pdf':
           return {
-            file: processedImage,
-            type: 'image',
-            preview: URL.createObjectURL(processedImage),
-            size: processedImage.size
+            file,
+            type: 'pdf',
+            preview: undefined,
+            size: file.size
           };
-        }
-      } else if (isPDF) {
-        return {
-          file,
-          type: 'pdf',
-          preview: undefined,
-          size: file.size
-        };
-      } else if (isMarkdown) {
-        const markdownFile = file.type.includes('markdown') ? file :
-          new File([file], file.name, { type: 'text/markdown' });
+          
+        case 'markdown':
+          const markdownFile = file.type.includes('markdown') ? file :
+            new File([file], file.name, { type: 'text/markdown' });
 
-        const preview = await this.generateMarkdownPreview(file);
+          const preview = await this.generateMarkdownPreview(file);
 
-        return {
-          file: markdownFile,
-          type: 'markdown',
-          preview,
-          size: file.size
-        };
+          return {
+            file: markdownFile,
+            type: 'markdown',
+            preview,
+            size: file.size
+          };
+          
+        case 'document':
+          return {
+            file,
+            type: 'document',
+            preview: undefined,
+            size: file.size
+          };
       }
 
       this.showNotification(`Unsupported file type: ${file.type}`, "error");

--- a/streamlit_chat_prompt/frontend/src/components/Types.tsx
+++ b/streamlit_chat_prompt/frontend/src/components/Types.tsx
@@ -1,4 +1,4 @@
-export type FileType = 'image' | 'pdf' | 'markdown' | 'document'; // | 'audio';
+export type FileType = 'image' | 'document'; // | 'audio';
 
 export interface SupportedFile {
   file: File;
@@ -7,28 +7,46 @@ export interface SupportedFile {
   size: number;
 }
 
+export const PREVIEWABLE_MIME_TYPES = [
+  'text/markdown',
+  'text/plain',
+  'text/html',
+  'text/csv',
+  'application/json'
+] as string[];
+
+export const PREVIEWABLE_EXTENSIONS = [
+  '.md', 
+  '.txt', 
+  '.html', 
+  '.htm', 
+  '.csv', 
+  '.json'
+] as string[];
+
 // Define file extensions and MIME types for each file type
 const FILE_DEFINITIONS = {
   image: {
     mimeTypes: ['image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/svg+xml'],
     extensions: ['.jpg', '.jpeg', '.png', '.gif', '.webp', '.svg']
   },
-  pdf: {
-    mimeTypes: ['application/pdf'],
-    extensions: ['.pdf']
-  },
-  markdown: {
-    mimeTypes: ['text/markdown', 'text/x-markdown'],
-    extensions: ['.md']
-  },
   document: {
     mimeTypes: [
+      // PDF
+      'application/pdf',
+      // Markdown
+      'text/markdown', 
+      'text/x-markdown',
+      // Word
       'application/msword', 
       'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      // Excel
       'application/vnd.ms-excel', 
       'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      // PowerPoint
       'application/vnd.ms-powerpoint', 
       'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+      // Other text formats
       'text/csv',
       'text/html',
       'text/plain',
@@ -36,9 +54,15 @@ const FILE_DEFINITIONS = {
       'application/json'
     ],
     extensions: [
+      // PDF
+      '.pdf',
+      // Markdown 
+      '.md',
+      // Office formats
       '.doc', '.docx', 
       '.xls', '.xlsx', 
-      '.ppt', '.pptx', 
+      '.ppt', '.pptx',
+      // Other formats 
       '.csv', 
       '.html', '.htm', 
       '.txt', 
@@ -82,9 +106,12 @@ export function getFileType(file: File): FileType {
 // Maintained for backward compatibility
 export const SUPPORTED_FILE_TYPES = {
   IMAGE: FILE_DEFINITIONS.image.mimeTypes,
-  PDF: FILE_DEFINITIONS.pdf.mimeTypes,
-  MARKDOWN: FILE_DEFINITIONS.markdown.mimeTypes,
-  DOCUMENT: FILE_DEFINITIONS.document.mimeTypes
+  DOCUMENT: FILE_DEFINITIONS.document.mimeTypes,
+  // Include these for backward compatibility if needed
+  PDF: FILE_DEFINITIONS.document.mimeTypes.filter(mime => mime === 'application/pdf'),
+  MARKDOWN: FILE_DEFINITIONS.document.mimeTypes.filter(mime => 
+    mime === 'text/markdown' || mime === 'text/x-markdown'
+  )
 };
 
 // Generate accept string for file input
@@ -119,4 +146,20 @@ export function isValidFileType(file: File): boolean {
   }
   
   return false;
+}
+
+export function isPreviewableDocument(file: File): boolean {
+  // Images are always previewable
+  if (file.type.startsWith('image/')) {
+    return true;
+  }
+
+  // Check MIME type first
+  if (PREVIEWABLE_MIME_TYPES.includes(file.type)) {
+    return true;
+  }
+
+  // Fallback to extension check
+  const filename = file.name.toLowerCase();
+  return PREVIEWABLE_EXTENSIONS.some(ext => filename.endsWith(ext));
 }

--- a/streamlit_chat_prompt/frontend/src/components/Types.tsx
+++ b/streamlit_chat_prompt/frontend/src/components/Types.tsx
@@ -1,24 +1,122 @@
+export type FileType = 'image' | 'pdf' | 'markdown' | 'document'; // | 'audio';
+
 export interface SupportedFile {
   file: File;
-  type: 'image' | 'pdf' | 'markdown'; // | 'audio';
+  type: FileType;
   preview?: string;
   size: number;
 }
 
-export const SUPPORTED_FILE_TYPES = {
-  IMAGE: ['image/jpeg', 'image/png', 'image/gif', 'image/webp'],
-  PDF: ['application/pdf'],
-  MARKDOWN: ['text/markdown', 'text/x-markdown', 'text/plain', 'application/x-markdown'],
-  // AUDIO: ['audio/mpeg', 'audio/wav', 'audio/ogg']
+// Define file extensions and MIME types for each file type
+const FILE_DEFINITIONS = {
+  image: {
+    mimeTypes: ['image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/svg+xml'],
+    extensions: ['.jpg', '.jpeg', '.png', '.gif', '.webp', '.svg']
+  },
+  pdf: {
+    mimeTypes: ['application/pdf'],
+    extensions: ['.pdf']
+  },
+  markdown: {
+    mimeTypes: ['text/markdown', 'text/x-markdown'],
+    extensions: ['.md']
+  },
+  document: {
+    mimeTypes: [
+      'application/msword', 
+      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      'application/vnd.ms-excel', 
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      'application/vnd.ms-powerpoint', 
+      'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+      'text/csv',
+      'text/html',
+      'text/plain',
+      'application/rtf',
+      'application/json'
+    ],
+    extensions: [
+      '.doc', '.docx', 
+      '.xls', '.xlsx', 
+      '.ppt', '.pptx', 
+      '.csv', 
+      '.html', '.htm', 
+      '.txt', 
+      '.rtf', 
+      '.json'
+    ]
+  }
 };
 
+// Create the FILE_TYPE_MAP from FILE_DEFINITIONS
+export const FILE_TYPE_MAP: Record<string, FileType> = {};
+Object.entries(FILE_DEFINITIONS).forEach(([type, def]) => {
+  def.mimeTypes.forEach(mime => {
+    FILE_TYPE_MAP[mime] = type as FileType;
+  });
+});
+
+// Helper function to get file type from MIME type or filename
+export function getFileType(file: File): FileType {
+  // First check by MIME type
+  if (file.type in FILE_TYPE_MAP) {
+    return FILE_TYPE_MAP[file.type];
+  }
+  
+  // Then check by file extension for cases where MIME type is ambiguous
+  const filename = file.name.toLowerCase();
+  
+  // Check each file type's extensions
+  for (const [type, def] of Object.entries(FILE_DEFINITIONS)) {
+    for (const ext of def.extensions) {
+      if (filename.endsWith(ext)) {
+        return type as FileType;
+      }
+    }
+  }
+  
+  // Default to document if we can't identify type
+  return 'document';
+}
+
+// Maintained for backward compatibility
+export const SUPPORTED_FILE_TYPES = {
+  IMAGE: FILE_DEFINITIONS.image.mimeTypes,
+  PDF: FILE_DEFINITIONS.pdf.mimeTypes,
+  MARKDOWN: FILE_DEFINITIONS.markdown.mimeTypes,
+  DOCUMENT: FILE_DEFINITIONS.document.mimeTypes
+};
+
+// Generate accept string for file input
 export function getAcceptedFileString(): string {
-  const accepts = [
-    'image/*', ".md", ".pdf",
-    ...SUPPORTED_FILE_TYPES.PDF,
-    ...SUPPORTED_FILE_TYPES.MARKDOWN
-    // ... SUPPORTED_FILE_TYPES.AUDIO
-  ];
+  const accepts = ['image/*'];
+  
+  // Add all extensions except image (covered by image/*)
+  for (const [type, def] of Object.entries(FILE_DEFINITIONS)) {
+    if (type !== 'image') {
+      accepts.push(...def.extensions);
+    }
+  }
   
   return accepts.join(',');
+}
+
+// Check if a file type is supported
+export function isValidFileType(file: File): boolean {
+  // First check by MIME type
+  if (file.type in FILE_TYPE_MAP) return true;
+  
+  // Then check by extension
+  const filename = file.name.toLowerCase();
+  
+  // Check all extensions from FILE_DEFINITIONS
+  for (const def of Object.values(FILE_DEFINITIONS)) {
+    for (const ext of def.extensions) {
+      if (filename.endsWith(ext)) {
+        return true;
+      }
+    }
+  }
+  
+  return false;
 }


### PR DESCRIPTION
Description:
- add support for all file extensions supported by AWS bedrock converse API
- refactor file type classification to use consistent 'image'/'document' categories
- add `is_previewable` property to FileData class to identify previewable content
- simplify code with centralized file type utilities in Types.tsx

Testing:
- tested by attaching `pdf|csv|doc|docx|xls|xlsx|html|txt|md` files

References:
- AWS Bedrock converse API for docs attachments: https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_DocumentBlock.html